### PR TITLE
Don't run seeds in prod

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,11 +6,10 @@
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
+unless Rails.env.production?
 
+  client = Account.create_with(password: "password", name: "Client", username: "client").find_or_create_by(email: "client@example.com")
+  worker = Account.create_with(password: "password", name: "Worker", username: "worker").find_or_create_by(email: "worker@example.com")
 
-client = Account.create_with(password: "password", name: "Client", username: "client").find_or_create_by(email: "client@example.com")
-worker = Account.create_with(password: "password", name: "Worker", username: "worker").find_or_create_by(email: "worker@example.com")
-
-
-
-arpa = client.owned_projects.find_or_create_by(name: "ARPANet")
+  arpa = client.owned_projects.find_or_create_by(name: "ARPANet")
+end


### PR DESCRIPTION
We accidentally seeded the production database with invalid data. I reset the database and am now preventing seeds from running in production
