### PR TITLE
Default total capacity owed to 0

### DIFF
--- a/db/migrate/20150519180259_add_default_to_total_capacity_owed.rb
+++ b/db/migrate/20150519180259_add_default_to_total_capacity_owed.rb
@@ -1,0 +1,5 @@
+class AddDefaultToTotalCapacityOwed < ActiveRecord::Migration
+  def change
+    change_column :projects, :total_capacity_owed, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150512191409) do
+ActiveRecord::Schema.define(version: 20150519180259) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,7 +57,7 @@ ActiveRecord::Schema.define(version: 20150512191409) do
     t.integer  "client_id"
     t.datetime "created_at",                      null: false
     t.datetime "updated_at",                      null: false
-    t.integer  "total_capacity_owed"
+    t.integer  "total_capacity_owed", default: 0
     t.integer  "capacity_used",       default: 0
     t.integer  "capacity_remaining",  default: 0
   end


### PR DESCRIPTION
We set a default value of 0 to total_capacity_owed on projects table. @zincmade/capacitor 
