### PR TITLE
Changed object to project because object is generic

### DIFF
--- a/app/decorators/project_decorator.rb
+++ b/app/decorators/project_decorator.rb
@@ -2,7 +2,7 @@ class ProjectDecorator < Draper::Decorator
   delegate_all
 
   def capacity_remaining
-    if object.capacity == -1
+    if project.capacity == -1
       "Infinity"
     else
       project.capacity_remaining


### PR DESCRIPTION
Switched `object` in `project_decorator`  to `project`
