### PR TITLE
Quality is now "How'd it go?"

### DIFF
--- a/app/helpers/project_helper.rb
+++ b/app/helpers/project_helper.rb
@@ -4,12 +4,12 @@ module ProjectHelper
   using CapacityConverter
   AMOUNT_OPTIONS = [1, 2, 4, 6, 8].map { |i| [i.to_business_days, i] }.unshift(nil)
 
-  WORST = "\xF0\x9F\x98\xA9"
-  BAD = "\xF0\x9F\x98\xA5"
-  OKAY = "\xF0\x9F\x98\x9E"
-  GOOD = "\xF0\x9F\x98\x84"
-  BEST = "\xF0\x9F\x98\x86"
-  QUALITY_OPTIONS = [[nil], [1, WORST], [2, BAD], [3, OKAY], [4, GOOD], [5, BEST]]
+  WORST = "😡"
+  BAD = "😟"
+  OKAY = "😐"
+  GOOD = "😌"
+  BEST = "😄"
+  QUALITY_OPTIONS = [[nil], [WORST, 1], [BAD, 2], [OKAY, 3], [GOOD, 4], [BEST, 5]]
 
   def options_for_project_amount
     options_for_select(AMOUNT_OPTIONS)

--- a/app/views/logs/_form.erb
+++ b/app/views/logs/_form.erb
@@ -3,7 +3,7 @@
   <%= f.select :amount, options_for_select(ProjectHelper::AMOUNT_OPTIONS, @log.amount) %>
   <%= render partial: "error_for_field", locals: { model: @log, field: :amount } %>
 
-  <%= f.label :quality %>
+  <%= f.label :quality, "How'd it go?" %>
   <%= f.select :quality, options_for_select(ProjectHelper::QUALITY_OPTIONS, @log.quality) %>
   <%= render partial: "error_for_field", locals: { model: @log, field: :quality } %>
 
@@ -18,7 +18,6 @@
   <% end %>
 
   <%= render partial: "error_for_field", locals: { model: @log, field: :do_not_bill } %>
-
 
   <%= f.submit "Log Capacity" %>
 <%- end %>

--- a/spec/features/logging_time_spec.rb
+++ b/spec/features/logging_time_spec.rb
@@ -11,7 +11,7 @@ feature "Logging time" do
   When { click_link_or_button "#{project.id}_new_log_entry" }
 
   When { select("1 half day", from: "Amount") }
-  When { select("4", from: "Quality") }
+  When { select("😌", from: "How'd it go?") }
   When { fill_in("Worked at", with: worked_at) }
 
   context "when tracking time as billable" do
@@ -36,7 +36,7 @@ feature "Editing time" do
   Given!(:decorated_log) { log.decorate }
 
   When { within("##{decorated_log.dom_id}") { click_link_or_button("Edit") } }
-  When { select("5", from: "Quality") }
+  When { select("😄", from: "How'd it go?") }
   When { click_link_or_button("Log Capacity") }
   Then { expect(log.reload.quality).to eql(5) }
 end


### PR DESCRIPTION
1. The order was backwards in the QUALITY_OPTIONS. It goes ["User facing value",
   "computer facing value"]
2. We can use the actual emoji characters in our source code.
3. Updated the tests to use the real emoji characters as well
