### PR TITLE
Stop requiring environment variables for puma

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,10 +1,10 @@
-workers(Integer(ENV["WEB_CONCURRENCY"]) || 2)
-threads(Integer(ENV["MIN_THREADS"]) || 5, Integer(ENV["MAX_THREADS"]) || 5)
+workers(Integer(ENV["WEB_CONCURRENCY"] || 2))
+threads(Integer(ENV["MIN_THREADS"] || 5), Integer(ENV["MAX_THREADS"] || 5))
 
 preload_app!
 
 rackup(DefaultRackup)
-port(Integer(ENV["PORT"]) || 3000)
+port(Integer(ENV["PORT"] || 3000))
 environment(ENV["RACK_ENV"] || "development")
 
 on_worker_boot do


### PR DESCRIPTION
We have defaults, but if we didn't set the environment variables the defaults were never loaded; which... isn't good...
