### PR TITLE
Update Ruby version in readme with a link so it doesn't get out of date

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Coverage](https://codeclimate.com/github/zincmade/capacitor/badges/coverage.svg)
 
 ## Getting Started
 
-1. Make sure you have the Ruby and Rails versions required in the [Gemfile](https://github.com/zincmade/capacitor/blob/primary/Gemfile)
+1. Make sure you have the Ruby version required in the [Gemfile](https://github.com/zincmade/capacitor/blob/primary/Gemfile)
 2. `bundle install`
 3. `cp .env.example .env`
 4. `bin/rake db:create db:migrate`

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Coverage](https://codeclimate.com/github/zincmade/capacitor/badges/coverage.svg)
 
 ## Getting Started
 
-1. Make sure you have Ruby 2.2.2
+1. Make sure you have the Ruby and Rails versions required in the [Gemfile](https://github.com/zincmade/capacitor/blob/primary/Gemfile)
 2. `bundle install`
 3. `cp .env.example .env`
 4. `bin/rake db:create db:migrate`


### PR DESCRIPTION
The readme said to install an outdated Ruby version. Linked to the Gemfile instead of hardcoding a version so it stays up to date
