### PR TITLE
204 show only a users active activities

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+  rescue_from UnauthorizedActionError, with: :deny_access
   before_action :authenticate_account!
   around_action :ensure_user_timezone
 
@@ -18,12 +19,16 @@ class ApplicationController < ActionController::Base
     devise_current_account.present? ? devise_current_account.decorate : nil
   end
 
-  def ensure_user_timezone(&block)
+  private def ensure_user_timezone(&block)
     if account_signed_in?
       Time.use_zone(current_account.time_zone, &block)
     else
       yield
     end
   end
-  private :ensure_user_timezone
+
+  private def deny_access
+    sign_out
+    redirect_to root_path
+  end
 end

--- a/app/controllers/check_ins_controller.rb
+++ b/app/controllers/check_ins_controller.rb
@@ -1,11 +1,11 @@
 # /check_ins/{new, create}
 class CheckInsController < ApplicationController
   def new
-    @check_in = CheckIn.new
+    @check_in = current_account.check_ins.new
   end
 
   def create
-    @check_in = CheckIn.new(check_in_params)
+    @check_in = current_account.check_ins.new(check_in_params)
     if @check_in.save
       flash[:notice] = "check in created!"
       track_check_in_creation(@check_in)

--- a/app/errors/unauthorized_action_error.rb
+++ b/app/errors/unauthorized_action_error.rb
@@ -1,0 +1,3 @@
+# Indicates that the requested action was inappropriate
+class UnauthorizedActionError < StandardError
+end

--- a/app/models/check_in.rb
+++ b/app/models/check_in.rb
@@ -3,6 +3,8 @@ class CheckIn < ActiveRecord::Base
   has_many :logs
   belongs_to :account
 
+  validates :account, presence: true
+
   accepts_nested_attributes_for :logs
 
   scope :recent, -> (start_at = 7.days.ago) do
@@ -14,7 +16,7 @@ class CheckIn < ActiveRecord::Base
   end
 
   def log_entries
-    Activity.active.map do |activity|
+    account.activities.active.map do |activity|
       logs.find_by(activity: activity) || logs.new(activity: activity)
     end
   end

--- a/app/policies/account_owns_all_policy.rb
+++ b/app/policies/account_owns_all_policy.rb
@@ -1,0 +1,15 @@
+
+  class AccountOwnsAllPolicy
+    attr_accessor :account
+    def initialize(account)
+      @account = account
+    end
+
+    def ensure_access!(attributes_collection, field, relation)
+      ids = (attributes_collection || {}).map do |id, attrs|
+        attrs[field]
+      end.compact
+
+      raise UnauthorizedActionError unless account.send(relation).where(id: ids).count == ids.count
+    end
+  end

--- a/app/policies/account_owns_all_policy.rb
+++ b/app/policies/account_owns_all_policy.rb
@@ -1,15 +1,16 @@
-
-  class AccountOwnsAllPolicy
-    attr_accessor :account
-    def initialize(account)
-      @account = account
-    end
-
-    def ensure_access!(attributes_collection, field, relation)
-      ids = (attributes_collection || {}).map do |id, attrs|
-        attrs[field]
-      end.compact
-
-      raise UnauthorizedActionError unless account.send(relation).where(id: ids).count == ids.count
-    end
+# Ensures account has a relation where all the ids match the field of passed
+# in collection of attributes
+class AccountOwnsAllPolicy
+  attr_accessor :account
+  def initialize(account)
+    @account = account
   end
+
+  def ensure_access!(attributes_collection, field, relation)
+    ids = (attributes_collection || {}).map do |_, attrs|
+      attrs[field]
+    end.compact
+
+    raise UnauthorizedActionError unless account.send(relation).where(id: ids).count == ids.count
+  end
+end

--- a/spec/features/checking_in_spec.rb
+++ b/spec/features/checking_in_spec.rb
@@ -26,8 +26,8 @@ feature "Checking in" do
   let(:fun_log_entry) { fun_activity.logs.last }
   let(:work_log_entry) { work_activity.logs.last }
   Given { (current_account.features.check_in = true) && current_account.save }
-  Given!(:fun_activity) { FactoryGirl.create(:activity, name: "Have Fun") }
-  Given!(:work_activity) { FactoryGirl.create(:activity, name: "Do Work") }
+  Given!(:fun_activity) { FactoryGirl.create(:activity, name: "Have Fun", owner: current_account) }
+  Given!(:work_activity) { FactoryGirl.create(:activity, name: "Do Work", owner: current_account) }
 
   When { click_link_or_button "Check In" }
 

--- a/spec/features/edit_check_in_spec.rb
+++ b/spec/features/edit_check_in_spec.rb
@@ -25,8 +25,8 @@ feature "Edit check in" do
   let(:worked_at) { 1.day.ago.strftime("%Y-%m-%d") }
   let(:fun_log_entry) { fun_activity.logs.last }
   let(:work_log_entry) { work_activity.logs.last }
-  Given!(:fun_activity) { FactoryGirl.create(:activity, name: "Have Fun") }
-  Given!(:work_activity) { FactoryGirl.create(:activity, name: "Do Work") }
+  Given!(:fun_activity) { FactoryGirl.create(:activity, name: "Have Fun", owner: current_account) }
+  Given!(:work_activity) { FactoryGirl.create(:activity, name: "Do Work", owner: current_account) }
   Given!(:check_in) { FactoryGirl.create(:check_in, account: current_account) }
   Given(:decorated_check_in) { check_in.decorate }
   Given { (current_account.features.check_in = true) && current_account.save }

--- a/spec/policies/account_owns_all_policy_spec.rb
+++ b/spec/policies/account_owns_all_policy_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe AccountOwnsAllPolicy do
+  let(:account) { FactoryGirl.create(:account_who_checked_in_yesterday) }
+  subject(:policy) { described_class.new(account) }
+  it "raises an exception when the account doesn't doesn't own all of the passed in attributes" do
+    expect do
+      policy.ensure_access!({ 0 => { id: account.check_ins.first.id }, 1 => { id: 235 } }, :id, :check_ins)
+    end.to raise_error UnauthorizedActionError
+  end
+
+  it "does not raise when the account owns all the passed in attributes" do
+    expect do
+      policy.ensure_access!({ 0 => { id: account.check_ins.first.id } }, :id, :check_ins)
+    end.not_to raise_error
+  end
+end


### PR DESCRIPTION
Connects #204 
- [x] Add tests to ensure that we only show activities for the logged in user
- [x] Fix the codeclimate error; possibly by doing the following:

```
private def prevent_invalid_access(allowed_collection, attribute)
  requested_collection = check_in_params[:log_entries_attributes].map { |_, attrs| attrs[attribute] }.compact
  raise "YOU DID A BAD!" if allowed_collection.where(id: requested_collection).count != requested_collection.count
end

private def prevent_logging_against_others_activities
  prevent_invalid_access(current_account.activities, :activity_id)
end

 private def prevent_changing_others_logs
   prevent_invalid_access(logs, :id)
 end


```
