### PR TITLE
New check ins can start with a date from the URL

### DIFF
--- a/app/controllers/check_ins_controller.rb
+++ b/app/controllers/check_ins_controller.rb
@@ -1,7 +1,7 @@
 # /check_ins/{new, create}
 class CheckInsController < ApplicationController
   def new
-    @check_in = CheckIn.new
+    @check_in = CheckIn.new(check_in_params)
   end
 
   def create
@@ -42,14 +42,14 @@ class CheckInsController < ApplicationController
   end
 
   private def merge_worked_at_and_account_into_log_entries(check_in_params)
-    check_in_params[:log_entries_attributes].each do |_id, log_entry|
+    check_in_params.fetch(:log_entries_attributes, {}).each do |_id, log_entry|
       log_entry[:account] = current_account
       log_entry[:worked_at] = check_in_params[:worked_at]
     end
   end
 
   private def remove_empty_log_entries(check_in_params)
-    check_in_params[:log_entries_attributes].each do |id, log_entry|
+    check_in_params.fetch(:log_entries_attributes, {}).each do |id, log_entry|
       if log_entry[:quality].blank? || log_entry[:amount].blank?
         check_in_params[:log_entries_attributes].delete(id)
         next

--- a/app/controllers/check_ins_controller.rb
+++ b/app/controllers/check_ins_controller.rb
@@ -33,6 +33,7 @@ class CheckInsController < ApplicationController
   end
 
   private def check_in_params
+    return {} unless params.key?(:check_in)
     check_in_params =
       params.require(:check_in).permit(permitted_check_in_params)
     check_in_params[:account] = current_account

--- a/app/views/missing_check_in_mailer/missing_check_in.html.erb
+++ b/app/views/missing_check_in_mailer/missing_check_in.html.erb
@@ -5,7 +5,7 @@
   </head>
   <body>
     <p>
-      Psssstt! Remember to <%= link_to "check-in for #{@friendly_date}", new_check_in_url(autofill_date: @friendly_date) %>
+      Psssstt! Remember to <%= link_to "check-in for #{@friendly_date}", new_check_in_url(check_in: { worked_at: @friendly_date }) %>
     </p>
     <p> --Team Capacitor
     </p>

--- a/app/views/missing_check_in_mailer/missing_check_in.text.erb
+++ b/app/views/missing_check_in_mailer/missing_check_in.text.erb
@@ -1,3 +1,3 @@
-Psssstt! Remember to check-in for <%= @friendly_date %>: <%= new_check_in_url %>
+Psssstt! Remember to check-in for <%= @friendly_date %>: <%= new_check_in_url(check_in: { worked_at: @friendly_date }) %>
 
 --Team Capacitor


### PR DESCRIPTION
First, I reviewed the `check_in_params` and `permitted_check_in_params`
to figure out the structure of the hash that is used to set the
attributes. From there, I figured out that I need to pass in query
params of `check_in: { worked_at: "<Insert date here>" }`.

So I went to the check in mailer views and added them to the html and
text emails. From there, I went to
``http://localhost:3000/rails/mailers` to preview the email; and clicked
the link.

I got an exception in both
`merge_worked_at_and_account_into_log_entries` and
`remove_empty_log_entries` because I was calling `each` on `nil` because
the check_in_params hash didn't have the `log_entries_attributes` keys.

So I used `fetch` to retrieve the `log_entries_attributes` from the
hash, and default it to an empty hash; which makes that field no longer
required.

Connects #192
