### PR TITLE
Extract class to verify account owns the requested activities and logs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+  rescue_from UnauthorizedActionError, with: :deny_access
   before_action :authenticate_account!
   around_action :ensure_user_timezone
 
@@ -18,12 +19,16 @@ class ApplicationController < ActionController::Base
     devise_current_account.present? ? devise_current_account.decorate : nil
   end
 
-  def ensure_user_timezone(&block)
+  private def ensure_user_timezone(&block)
     if account_signed_in?
       Time.use_zone(current_account.time_zone, &block)
     else
       yield
     end
   end
-  private :ensure_user_timezone
+
+  private def deny_access
+    sign_out
+    redirect_to root_path
+  end
 end

--- a/app/errors/unauthorized_action_error.rb
+++ b/app/errors/unauthorized_action_error.rb
@@ -1,0 +1,3 @@
+# Indicates that the requested action was inappropriate
+class UnauthorizedActionError < StandardError
+end

--- a/app/policies/account_owns_all_policy.rb
+++ b/app/policies/account_owns_all_policy.rb
@@ -1,0 +1,15 @@
+
+  class AccountOwnsAllPolicy
+    attr_accessor :account
+    def initialize(account)
+      @account = account
+    end
+
+    def ensure_access!(attributes_collection, field, relation)
+      ids = (attributes_collection || {}).map do |id, attrs|
+        attrs[field]
+      end.compact
+
+      raise UnauthorizedActionError unless account.send(relation).where(id: ids).count == ids.count
+    end
+  end

--- a/spec/policies/account_owns_all_policy_spec.rb
+++ b/spec/policies/account_owns_all_policy_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe AccountOwnsAllPolicy do
+  let(:account) { FactoryGirl.create(:account_who_checked_in_yesterday) }
+  subject(:policy) { described_class.new(account) }
+  it "raises an exception when the account doesn't doesn't own all of the passed in attributes" do
+    expect do
+      policy.ensure_access!({ 0 => { id: account.check_ins.first.id }, 1 => { id: 235 } }, :id, :check_ins)
+    end.to raise_error UnauthorizedActionError
+  end
+
+  it "does not raise when the account owns all the passed in attributes" do
+    expect do
+      policy.ensure_access!({ 0 => { id: account.check_ins.first.id } }, :id, :check_ins)
+    end.not_to raise_error
+  end
+end


### PR DESCRIPTION
This allows us to re-use the core logic of "hey, here's a collection of
attributes, is it OK for the current account to edit them?"

It also now throws a NotAuthorizedError in the event that the object
isn't the owner of all the passed in model attributes. This allows us to
recover from that error by signing out the user.
